### PR TITLE
Fixed smart error with player name

### DIFF
--- a/lib/jwplayer/rails/helper.rb
+++ b/lib/jwplayer/rails/helper.rb
@@ -2,7 +2,7 @@ module JWPlayer::Rails
   module Helper
     DEFAULT_OPTIONS = {
       id: 'jwplayer',
-      flashplayer: '/assets/player.swf',
+      flashplayer: '/assets/flash.swf',
       width: '400',
       height: '300'
     }


### PR DESCRIPTION
I have modified the swf player name. You had an error with this file in name. Now is working fine with `flash.swf` file name.

You can push this pull If you consider it appropriate.

Best regards!
