### PR TITLE
Custom loading text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can pass options to jwplayer helper to customize it:
 More information for customization could be found [here](http://www.longtailvideo.com/support/jw-player/28839/embedding-the-player)
 
 The text showed before the JwPlayer loads can be defined with the text option:
-    <%= jwplayer({text: "<p>Loading..</p>"}) %>
+
+    <%= jwplayer({text: "Loading.."}) %>
 
 Have fun!

--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ You can pass options to jwplayer helper to customize it:
 
 More information for customization could be found [here](http://www.longtailvideo.com/support/jw-player/28839/embedding-the-player)
 
+The text showed before the JwPlayer loads can be defined with the text option:
+    <%= jwplayer({text: "<p>Loading..</p>"}) %>
+
 Have fun!

--- a/lib/jwplayer/rails/helper.rb
+++ b/lib/jwplayer/rails/helper.rb
@@ -14,8 +14,10 @@ module JWPlayer::Rails
 
     def jwplayer(options = {})
       options = DEFAULT_OPTIONS.merge(options)
-
-      result = %Q{<div id='#{options[:id]}'>This div will be replaced by the JW Player.</div>
+      if not options[:text]
+        options[:text] = "This div will be replaced by the JW Player."
+      end
+      result = %Q{<div id='#{options[:id]}'>#{options[:text]}</div>
                   <script type='text/javascript'>
                     jwplayer('#{options[:id]}').setup(#{options.except(:id).to_json});
                   </script>}

--- a/lib/jwplayer/rails/version.rb
+++ b/lib/jwplayer/rails/version.rb
@@ -1,6 +1,6 @@
 module JWPlayer
   module Rails
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
     JWPLAYER_VERSION = "6.2.3115"
   end
 end


### PR DESCRIPTION
The text showed before JwPlayer loads can be defined as option. This is great for multi-language support and spinner/loaders. The text defaults to the current one
